### PR TITLE
Add leafsPath option

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,12 +10,24 @@ program
   .option('--destDirPath [value]', 'dir you want to store the generated queries')
   .option('--depthLimit [value]', 'query depth you want to limit(The default is 100)')
   .option('-C, --includeDeprecatedFields [value]', 'Flag to include deprecated fields (The default is to exclude)')
+  .option('-L, --leafsPath [value]', 'path of a file which specifies which types and fields to treat as leafs')
   .parse(process.argv);
 
-const { schemaFilePath, destDirPath, depthLimit = 100, includeDeprecatedFields = false } = program;
+const { schemaFilePath, destDirPath, depthLimit = 100, includeDeprecatedFields = false, leafsPath } = program;
 const typeDef = fs.readFileSync(schemaFilePath);
 const source = new Source(typeDef);
 const gqlSchema = buildSchema(source);
+
+/*
+ * The leaf file should contain an object with types and fields.
+ * e.g.
+ * {
+ *   ALeafType: ['fieldToInclude', 'anotherFieldToInclude']
+ *   AnotherLeafType: ['fieldToInclude', 'anotherFieldToInclude']
+ * }
+ */
+
+const leafs = leafsPath ? JSON.parse(fs.readFileSync(leafsPath)) : {};
 
 del.sync(destDirPath);
 path.resolve(destDirPath).split(path.sep).reduce((before, cur) => {
@@ -87,6 +99,7 @@ const generateQuery = (
   curDepth = 1,
 ) => {
   const field = gqlSchema.getType(curParentType).getFields()[curName];
+  const topLevel = ['Query', 'Mutation', 'Subscription'].includes(curParentType);
   const curTypeName = field.type.inspect().replace(/[[\]!]/g, '');
   const curType = gqlSchema.getType(curTypeName);
   let queryStr = '';
@@ -97,11 +110,18 @@ const generateQuery = (
     if (crossReferenceKeyList.indexOf(crossReferenceKey) !== -1 || curDepth > depthLimit) return '';
     crossReferenceKeyList.push(crossReferenceKey);
     const childKeys = Object.keys(curType.getFields());
+    const leaf = leafs[curType];
     childQuery = childKeys
       .filter(fieldName => {
+        let include;
         /* Exclude deprecated fields */
-        const fieldSchema = gqlSchema.getType(curType).getFields()[fieldName];
-        return includeDeprecatedFields || !fieldSchema.isDeprecated;
+        include = gqlSchema.getType(curType).getFields()[fieldName];
+
+        /* If this is a leaf type, exclude non-leaf fields */
+        /* Types can only be leaves if they are nested, i.e. they are not at the top level */
+        include = include && (topLevel || !leaf || leaf.includes(fieldName));
+
+        return include
       })
       .map(cur => generateQuery(cur, curType, curName, argumentsDict, duplicateArgCounts,
         crossReferenceKeyList, curDepth + 1).queryStr)
@@ -123,6 +143,7 @@ const generateQuery = (
 
   /* Union types */
   if (curType.astNode && curType.astNode.kind === 'UnionTypeDefinition') {
+    const unionLeaf = leafs[curType]; // allows user to specify leaf fields on a union.
     const types = curType.getTypes();
     if (types && types.length) {
       const indent = `${'    '.repeat(curDepth)}`;
@@ -132,7 +153,18 @@ const generateQuery = (
       for (let i = 0, len = types.length; i < len; i++) {
         const valueTypeName = types[i];
         const valueType = gqlSchema.getType(valueTypeName);
+        const typeLeaf = leafs[valueType];
         const unionChildQuery = Object.keys(valueType.getFields())
+          .filter(fieldName => {
+            let include = true;
+            /* If this is a leaf type, exclude non-leaf fields */
+            /* Types can only be leaves if they are nested, i.e. they are not at the top level */
+            if (!topLevel) {
+              if (unionLeaf && !unionLeaf.includes(fieldName)) include = false;
+              if (typeLeaf && !typeLeaf.includes(fieldName)) include = false;
+            }
+            return include;
+          })
           .map(cur => generateQuery(cur, valueType, curName, argumentsDict, duplicateArgCounts,
             crossReferenceKeyList, curDepth + 2).queryStr)
           .filter(cur => cur)


### PR DESCRIPTION
Hi!

This PR adds support for an optional `--leafsPath` command line argument. If provided, the `leafs` file should contain a JSON object with GraphQL types (including unions, if desired) as keys and "leaf" fields to include as as array values. For example:

```
 {
   ALeafType: ['fieldToInclude', 'anotherFieldToInclude']
   AnotherLeafType: ['fieldToInclude', 'anotherFieldToInclude']
 }
```

When `gql-generator` encounters the listed types anywhere other than at the top-level, it will exclude any fields not included in the associated array.

We implemented this because we use a lot of nested revolvers, and the queries, while useful, were also large and unwieldy. This feature allows us to still generate comprehensive queries, without the redundant overkill of traversing Types that have their own stand-alone queries.

I implemented this feature for my team's internal use. If this doesn't seem generally useful to others, feel free to close this PR.