### PR TITLE
fix: Correct display of union child, fix empty braces when no fields on selected deep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 # output files of test
-example/output
-example/output2
-example/output3
-example/output4
+example/output*
 
 # Logs
 logs

--- a/example/sampleTypeDef.graphql
+++ b/example/sampleTypeDef.graphql
@@ -54,7 +54,7 @@ type User {
     address: String! @deprecated(reason: "Test a deprecated field")
 }
 
-union UserDetails = Guest | Member
+union UserDetails = Guest | Member | Premium
 
 type Guest {
     region(language: String): String!
@@ -62,6 +62,20 @@ type Guest {
 
 type Member {
     address: String!
+}
+
+type Premium {
+    location: String!
+    card: Card!
+}
+
+type Card {
+    number: String!
+    type: [CardType!]!
+}
+
+type CardType {
+    key: String!
 }
 
 type Context {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gql-generator",
-  "version": "1.0.8",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gql-generator",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ test('limit depth', async () => {
 test('excludes deprecated fields by default', async () => {
   cp.execSync('node index.js --schemaFilePath ./example/sampleTypeDef.graphql --destDirPath ./example/output3 --depthLimit 1');
   const queries = require('../example/output3');
-  should(typeof queries.queries.user).be.exactly("string");
+  should(typeof queries.queries.user).be.exactly('string');
   should(queries.queries.members === undefined).be.true();
   should(queries.mutations.sendMessage === undefined).be.true();
 
@@ -33,20 +33,23 @@ test('excludes deprecated fields by default', async () => {
             ... on Member {
                 address
             }
+            ... on Premium {
+                location
+            }
         }
     }
-}`
+}`;
 
-  should(queries.queries.user === expected).be.true();  
+  should(queries.queries.user === expected).be.true();
 });
 
 test('includes deprecated fields with includeDeprecatedFields flag', async () => {
   cp.execSync('node index.js --schemaFilePath ./example/sampleTypeDef.graphql --destDirPath ./example/output4 --depthLimit 1 --includeDeprecatedFields');
   const queries = require('../example/output4');
 
-  should(typeof queries.queries.user).be.exactly("string");
-  should(typeof queries.queries.members).be.exactly("string");
-  should(typeof queries.mutations.sendMessage).be.exactly("string");
+  should(typeof queries.queries.user).be.exactly('string');
+  should(typeof queries.queries.members).be.exactly('string');
+  should(typeof queries.mutations.sendMessage).be.exactly('string');
 
   const expected = `query user($language: String, $id: Int!){
     user(id: $id){
@@ -61,9 +64,48 @@ test('includes deprecated fields with includeDeprecatedFields flag', async () =>
             ... on Member {
                 address
             }
+            ... on Premium {
+                location
+            }
         }
         address
     }
-}`
+}`;
   should(queries.queries.user === expected).be.true();
+});
+
+test('includes nested in union types', async () => {
+  cp.execSync('node index.js --schemaFilePath ./example/sampleTypeDef.graphql --destDirPath ./example/output5 --depthLimit 2');
+  const queries = require('../example/output5');
+
+  should(typeof queries.queries.user).be.exactly('string');
+  should(queries.queries.members === undefined).be.true();
+  should(queries.mutations.sendMessage === undefined).be.true();
+
+  const expected = `query user($language: String, $id: Int!){
+    user(id: $id){
+        id
+        username
+        email
+        createdAt
+        context{
+            domain
+        }
+        details{
+            ... on Guest {
+                region(language: $language)
+            }
+            ... on Member {
+                address
+            }
+            ... on Premium {
+                location
+                card{
+                    number
+                }
+            }
+        }
+    }
+}`;
+  should(queries.queries.user).be.equal(expected);
 });


### PR DESCRIPTION
Correct display of union child, fix empty braces when no fields on selected deep
Linked issue: #37 