### PR TITLE
Enable to use custom Query/Mutation/Subscription naming

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,21 @@ const generateFile = (obj, description) => {
       const queryResult = generateQuery(type, description);
       const varsToTypesStr = getVarsToTypesStr(queryResult.argumentsDict);
       let query = queryResult.queryStr;
-      query = `${description.toLowerCase()} ${type}${varsToTypesStr ? `(${varsToTypesStr})` : ''}{\n${query}\n}`;
+      let queryName;
+      switch (true) {
+        case /Mutation/.test(description):
+          queryName = 'mutation';
+          break;
+        case /Query/.test(description):
+          queryName = 'query';
+          break;
+        case /Subscription/.test(description):
+          queryName = 'subscription';
+          break;
+        default:
+          break;
+      }
+      query = `${queryName || description.toLowerCase()} ${type}${varsToTypesStr ? `(${varsToTypesStr})` : ''}{\n${query}\n}`;
       fs.writeFileSync(path.join(writeFolder, `./${type}.${fileExtension}`), query);
       indexJs += `module.exports.${type} = fs.readFileSync(path.join(__dirname, '${type}.${fileExtension}'), 'utf8');\n`;
     }

--- a/index.js
+++ b/index.js
@@ -164,14 +164,14 @@ const generateQuery = (
 const generateFile = (obj, description) => {
   let indexJs = 'const fs = require(\'fs\');\nconst path = require(\'path\');\n\n';
   let outputFolderName;
-  switch (description) {
-    case 'Mutation':
+  switch (true) {
+    case /Mutation$/.test(description):
       outputFolderName = 'mutations';
       break;
-    case 'Query':
+    case /Query$/.test(description):
       outputFolderName = 'queries';
       break;
-    case 'Subscription':
+    case /Subscription$/.test(description):
       outputFolderName = 'subscriptions';
       break;
     default:
@@ -200,19 +200,19 @@ const generateFile = (obj, description) => {
 };
 
 if (gqlSchema.getMutationType()) {
-  generateFile(gqlSchema.getMutationType().getFields(), 'Mutation');
+  generateFile(gqlSchema.getMutationType().getFields(), gqlSchema.getMutationType().name);
 } else {
   console.log('[gqlg warning]:', 'No mutation type found in your schema');
 }
 
 if (gqlSchema.getQueryType()) {
-  generateFile(gqlSchema.getQueryType().getFields(), 'Query');
+  generateFile(gqlSchema.getQueryType().getFields(), gqlSchema.getQueryType().name);
 } else {
   console.log('[gqlg warning]:', 'No query type found in your schema');
 }
 
 if (gqlSchema.getSubscriptionType()) {
-  generateFile(gqlSchema.getSubscriptionType().getFields(), 'Subscription');
+  generateFile(gqlSchema.getSubscriptionType().getFields(), gqlSchema.getSubscriptionType().name);
 } else {
   console.log('[gqlg warning]:', 'No subscription type found in your schema');
 }


### PR DESCRIPTION
This PR solves https://github.com/timqian/gql-generator/issues/27.

During development we also run into issue that our queries and mutations are named `RootQuery` and `RootMutation` (which is by the way a very common practice) and this prevents us to use this tool. Renaming them is not an option since the types generated from them are used across many other projects and we can't change them.

I tested these changes with our schema and it works great. Also it's a small, non-breaking change that would solve quite a huge issue so I hope this will become part of the library soon, otherwise the only way to use it is to fork it to our project and add those changes there.

Will be waiting for updates, thanks! 🤞 