### PR TITLE
flag to support buildSchema assumeValidSDL param

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,16 +9,23 @@ program
   .option('--schemaFilePath [value]', 'path of your graphql schema file')
   .option('--destDirPath [value]', 'dir you want to store the generated queries')
   .option('--depthLimit [value]', 'query depth you want to limit(The default is 100)')
+  .option('--assumeValid [value]', 'assume the SDL is valid(The default is false)')
   .option('--ext [value]', 'extension file to use', 'gql')
   .option('-C, --includeDeprecatedFields [value]', 'Flag to include deprecated fields (The default is to exclude)')
   .parse(process.argv);
 
 const {
-  schemaFilePath, destDirPath, depthLimit = 100, includeDeprecatedFields = false, ext: fileExtension,
+  schemaFilePath, destDirPath, depthLimit = 100, includeDeprecatedFields = false, ext: fileExtension, assumeValid
 } = program;
+
+let assume = false
+if(assumeValid === "true") {
+    assume = true
+}
+
 const typeDef = fs.readFileSync(schemaFilePath, 'utf-8');
 const source = new Source(typeDef);
-const gqlSchema = buildSchema(source);
+const gqlSchema = buildSchema(source, { assumeValidSDL: assume });
 
 del.sync(destDirPath);
 path.resolve(destDirPath).split(path.sep).reduce((before, cur) => {


### PR DESCRIPTION
Allows for custom types and directives to be involved in a schema. Is currently supported in graphql `BuildSchema` --> https://github.com/graphql/graphql-js/issues/1854#issuecomment-490353851

I am using gql-generator to build out query samples, and we use custom types and directives in our schemas. We do not need the validator.

With this PR, the CLI can add this flag, `--assumeValid true`

`gqlg --schemaFilePath index.graphql --destDirPath ./example/output --depthLimit 5 --assumeValid true`

```
Error: Unknown directive "@rest".
    at assertValidSDL (/Users/samuelhill/Desktop/app/node_modules/graphql/validation/validate.js:135:11)
    at buildASTSchema (/Users/samuelhill/Desktop/app/node_modules/graphql/utilities/buildASTSchema.js:44:34)
    at buildSchema (/Users/samuelhill/Desktop/app/node_modules/graphql/utilities/buildASTSchema.js:109:10)
    at Object.<anonymous> (/Users/samuelhill/Desktop/app/node_modules/gql-generator/index.js:28:19)
    at Module._compile (internal/modules/cjs/loader.js:1068:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:933:32)
    at Function.Module._load (internal/modules/cjs/loader.js:774:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
```