### PR TITLE
Flag for including cross-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ test('signup', async () => {
 
 ## Notes
 
-- As this tool is used for tests, it expands all of the fields in a query. There might be recursive fields in the query, so `gqlg` ignores the types which have been added in the parent queries already.
+- As this tool is used for tests, it expands all of the fields in a query. There might be recursive fields in the query, so `gqlg` ignores the types which have been added in the parent queries already by default. This can be disabled using the `--includeCrossReferences` argument.
 - Variable names are derived from argument names, so variables generated from multiple occurrences of the same argument name must be deduped. An index is appended to any duplicates e.g. `region(language: $language1)`.
 
 > [Donate with bitcoin](https://getcryptoo.github.io/)

--- a/index.js
+++ b/index.js
@@ -8,19 +8,26 @@ const del = require('del');
 program
   .option('--schemaFilePath [value]', 'path of your graphql schema file')
   .option('--destDirPath [value]', 'dir you want to store the generated queries')
-  .option('--depthLimit [value]', 'query depth you want to limit(The default is 100)')
-  .option('--assumeValid [value]', 'assume the SDL is valid(The default is false)')
+  .option('--depthLimit [value]', 'query depth you want to limit (The default is 100)')
+  .option('--assumeValid [value]', 'assume the SDL is valid (The default is false)')
   .option('--ext [value]', 'extension file to use', 'gql')
   .option('-C, --includeDeprecatedFields [value]', 'Flag to include deprecated fields (The default is to exclude)')
+  .option('-R, --includeCrossReferences', 'Flag to include fields that have been added to parent queries already (The default is to exclude)')
   .parse(process.argv);
 
 const {
-  schemaFilePath, destDirPath, depthLimit = 100, includeDeprecatedFields = false, ext: fileExtension, assumeValid
+  schemaFilePath,
+  destDirPath,
+  depthLimit = 100,
+  includeDeprecatedFields = false,
+  ext: fileExtension,
+  assumeValid,
+  includeCrossReferences = false,
 } = program;
 
-let assume = false
-if(assumeValid === "true") {
-    assume = true
+let assume = false;
+if (assumeValid === 'true') {
+  assume = true;
 }
 
 const typeDef = fs.readFileSync(schemaFilePath, 'utf-8');
@@ -106,7 +113,12 @@ const generateQuery = (
 
   if (curType.getFields) {
     const crossReferenceKey = `${curParentName}To${curName}Key`;
-    if (crossReferenceKeyList.indexOf(crossReferenceKey) !== -1 || (fromUnion ? curDepth - 2 : curDepth) > depthLimit) return '';
+    if (
+      (!includeCrossReferences && crossReferenceKeyList.indexOf(crossReferenceKey) !== -1)
+      || (fromUnion ? curDepth - 2 : curDepth) > depthLimit
+    ) {
+      return '';
+    }
     if (!fromUnion) {
       crossReferenceKeyList.push(crossReferenceKey);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -109,3 +109,66 @@ test('includes nested in union types', async () => {
 }`;
   should(queries.queries.user).be.equal(expected);
 });
+
+test('includes cross reference with the --includeCrossReferences flag', async () => {
+  cp.execSync('node index.js --schemaFilePath ./example/sampleTypeDef.graphql --destDirPath ./example/output6 --depthLimit 4 --includeCrossReferences');
+  const queries = require('../example/output6');
+
+  should(typeof queries.queries.user).be.exactly('string');
+  should(queries.queries.members === undefined).be.true();
+  should(queries.mutations.sendMessage === undefined).be.true();
+
+  // The context domain field should be included multiple times
+  const expected = `query user($language: String, $language1: String, $id: Int!){
+    user(id: $id){
+        id
+        username
+        email
+        createdAt
+        context{
+            user{
+                id
+                username
+                email
+                createdAt
+                context{
+                    domain
+                }
+                details{
+                    ... on Guest {
+                        region(language: $language)
+                    }
+                    ... on Member {
+                        address
+                    }
+                    ... on Premium {
+                        location
+                        card{
+                            number
+                        }
+                    }
+                }
+            }
+            domain
+        }
+        details{
+            ... on Guest {
+                region(language: $language1)
+            }
+            ... on Member {
+                address
+            }
+            ... on Premium {
+                location
+                card{
+                    number
+                    type{
+                        key
+                    }
+                }
+            }
+        }
+    }
+}`;
+  should(queries.queries.user).be.equal(expected);
+});


### PR DESCRIPTION
Added a `includeCrossReferences` flag (or `-R`), would close https://github.com/timqian/gql-generator/issues/51

This would be nice to have for my own use case as well, for generating queries for a headless CMS which I then use to generate TypeScript types. The schema can have many nested fields, which makes maintaining queries by hand very cumbersome when the schema is frequently updated during development