### PR TITLE
add programmatic access

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ mutation signup($username: String!, email: String!, password: String!){
 
 The tool will automatically exclude any `@deprecated` schema fields (see more on schema directives [here](https://www.apollographql.com/docs/graphql-tools/schema-directives)). To change this behavior to include deprecated fields you can use the `includeDeprecatedFields` flag when running the tool, e.g. `gqlg --includeDeprecatedFields`.
 
+### Programmatic Access
+
+Alternatively, you can run `gql-generator` directly from your scripts:
+
+```js
+const gqlg = require('gql-generator')
+
+gqlg({ schemaFilePath: './example/sampleTypeDef.graphql', destDirPath: './example/output', depthLimit: 5 })
+```
+
 ## Usage example
 
 Say you have a graphql schema like this: 

--- a/index.js
+++ b/index.js
@@ -5,249 +5,255 @@ const program = require('commander');
 const { Source, buildSchema } = require('graphql');
 const del = require('del');
 
-program
-  .option('--schemaFilePath [value]', 'path of your graphql schema file')
-  .option('--destDirPath [value]', 'dir you want to store the generated queries')
-  .option('--depthLimit [value]', 'query depth you want to limit (The default is 100)')
-  .option('--assumeValid [value]', 'assume the SDL is valid (The default is false)')
-  .option('--ext [value]', 'extension file to use', 'gql')
-  .option('-C, --includeDeprecatedFields [value]', 'Flag to include deprecated fields (The default is to exclude)')
-  .option('-R, --includeCrossReferences', 'Flag to include fields that have been added to parent queries already (The default is to exclude)')
-  .parse(process.argv);
-
-const {
+function main ({
   schemaFilePath,
   destDirPath,
   depthLimit = 100,
   includeDeprecatedFields = false,
-  ext: fileExtension,
+  fileExtension,
   assumeValid,
   includeCrossReferences = false,
-} = program;
-
-let assume = false;
-if (assumeValid === 'true') {
-  assume = true;
-}
-
-const typeDef = fs.readFileSync(schemaFilePath, 'utf-8');
-const source = new Source(typeDef);
-const gqlSchema = buildSchema(source, { assumeValidSDL: assume });
-
-del.sync(destDirPath);
-path.resolve(destDirPath).split(path.sep).reduce((before, cur) => {
-  const pathTmp = path.join(before, cur + path.sep);
-  if (!fs.existsSync(pathTmp)) {
-    fs.mkdirSync(pathTmp);
-  }
-  return path.join(before, cur + path.sep);
-}, '');
-let indexJsExportAll = '';
-
-/**
- * Compile arguments dictionary for a field
- * @param field current field object
- * @param duplicateArgCounts map for deduping argument name collisions
- * @param allArgsDict dictionary of all arguments
- */
-const getFieldArgsDict = (
-  field,
-  duplicateArgCounts,
-  allArgsDict = {},
-) => field.args.reduce((o, arg) => {
-  if (arg.name in duplicateArgCounts) {
-    const index = duplicateArgCounts[arg.name] + 1;
-    duplicateArgCounts[arg.name] = index;
-    o[`${arg.name}${index}`] = arg;
-  } else if (allArgsDict[arg.name]) {
-    duplicateArgCounts[arg.name] = 1;
-    o[`${arg.name}1`] = arg;
-  } else {
-    o[arg.name] = arg;
-  }
-  return o;
-}, {});
-
-/**
- * Generate variables string
- * @param dict dictionary of arguments
- */
-const getArgsToVarsStr = dict => Object.entries(dict)
-  .map(([varName, arg]) => `${arg.name}: $${varName}`)
-  .join(', ');
-
-/**
- * Generate types string
- * @param dict dictionary of arguments
- */
-const getVarsToTypesStr = dict => Object.entries(dict)
-  .map(([varName, arg]) => `$${varName}: ${arg.type}`)
-  .join(', ');
-
-/**
- * Generate the query for the specified field
- * @param curName name of the current field
- * @param curParentType parent type of the current field
- * @param curParentName parent name of the current field
- * @param argumentsDict dictionary of arguments from all fields
- * @param duplicateArgCounts map for deduping argument name collisions
- * @param crossReferenceKeyList list of the cross reference
- * @param curDepth current depth of field
- * @param fromUnion adds additional depth for unions to avoid empty child
- */
-const generateQuery = (
-  curName,
-  curParentType,
-  curParentName,
-  argumentsDict = {},
-  duplicateArgCounts = {},
-  crossReferenceKeyList = [], // [`${curParentName}To${curName}Key`]
-  curDepth = 1,
-  fromUnion = false,
-) => {
-  const field = gqlSchema.getType(curParentType).getFields()[curName];
-  const curTypeName = field.type.toJSON().replace(/[[\]!]/g, '');
-  const curType = gqlSchema.getType(curTypeName);
-  let queryStr = '';
-  let childQuery = '';
-
-  if (curType.getFields) {
-    const crossReferenceKey = `${curParentName}To${curName}Key`;
-    if (
-      (!includeCrossReferences && crossReferenceKeyList.indexOf(crossReferenceKey) !== -1)
-      || (fromUnion ? curDepth - 2 : curDepth) > depthLimit
-    ) {
-      return '';
-    }
-    if (!fromUnion) {
-      crossReferenceKeyList.push(crossReferenceKey);
-    }
-    const childKeys = Object.keys(curType.getFields());
-    childQuery = childKeys
-      .filter((fieldName) => {
-        /* Exclude deprecated fields */
-        const fieldSchema = gqlSchema.getType(curType).getFields()[fieldName];
-        return includeDeprecatedFields || !fieldSchema.deprecationReason;
-      })
-      .map(cur => generateQuery(cur, curType, curName, argumentsDict, duplicateArgCounts,
-        crossReferenceKeyList, curDepth + 1, fromUnion).queryStr)
-      .filter(cur => Boolean(cur))
-      .join('\n');
+} = {}) {
+  let assume = false;
+  if (assumeValid === 'true') {
+    assume = true;
   }
 
-  if (!(curType.getFields && !childQuery)) {
-    queryStr = `${'    '.repeat(curDepth)}${field.name}`;
-    if (field.args.length > 0) {
-      const dict = getFieldArgsDict(field, duplicateArgCounts, argumentsDict);
-      Object.assign(argumentsDict, dict);
-      queryStr += `(${getArgsToVarsStr(dict)})`;
+  const typeDef = fs.readFileSync(schemaFilePath, 'utf-8');
+  const source = new Source(typeDef);
+  const gqlSchema = buildSchema(source, { assumeValidSDL: assume });
+
+  del.sync(destDirPath);
+  path.resolve(destDirPath).split(path.sep).reduce((before, cur) => {
+    const pathTmp = path.join(before, cur + path.sep);
+    if (!fs.existsSync(pathTmp)) {
+      fs.mkdirSync(pathTmp);
     }
-    if (childQuery) {
-      queryStr += `{\n${childQuery}\n${'    '.repeat(curDepth)}}`;
+    return path.join(before, cur + path.sep);
+  }, '');
+  let indexJsExportAll = '';
+
+  /**
+   * Compile arguments dictionary for a field
+   * @param field current field object
+   * @param duplicateArgCounts map for deduping argument name collisions
+   * @param allArgsDict dictionary of all arguments
+   */
+  const getFieldArgsDict = (
+    field,
+    duplicateArgCounts,
+    allArgsDict = {},
+  ) => field.args.reduce((o, arg) => {
+    if (arg.name in duplicateArgCounts) {
+      const index = duplicateArgCounts[arg.name] + 1;
+      duplicateArgCounts[arg.name] = index;
+      o[`${arg.name}${index}`] = arg;
+    } else if (allArgsDict[arg.name]) {
+      duplicateArgCounts[arg.name] = 1;
+      o[`${arg.name}1`] = arg;
+    } else {
+      o[arg.name] = arg;
     }
-  }
+    return o;
+  }, {});
 
-  /* Union types */
-  if (curType.astNode && curType.astNode.kind === 'UnionTypeDefinition') {
-    const types = curType.getTypes();
-    if (types && types.length) {
-      const indent = `${'    '.repeat(curDepth)}`;
-      const fragIndent = `${'    '.repeat(curDepth + 1)}`;
-      queryStr += '{\n';
+  /**
+   * Generate variables string
+   * @param dict dictionary of arguments
+   */
+  const getArgsToVarsStr = dict => Object.entries(dict)
+    .map(([varName, arg]) => `${arg.name}: $${varName}`)
+    .join(', ');
 
-      for (let i = 0, len = types.length; i < len; i++) {
-        const valueTypeName = types[i];
-        const valueType = gqlSchema.getType(valueTypeName);
-        const unionChildQuery = Object.keys(valueType.getFields())
-          .map(cur => generateQuery(cur, valueType, curName, argumentsDict, duplicateArgCounts,
-            crossReferenceKeyList, curDepth + 2, true).queryStr)
-          .filter(cur => Boolean(cur))
-          .join('\n');
+  /**
+   * Generate types string
+   * @param dict dictionary of arguments
+   */
+  const getVarsToTypesStr = dict => Object.entries(dict)
+    .map(([varName, arg]) => `$${varName}: ${arg.type}`)
+    .join(', ');
 
-        /* Exclude empty unions */
-        if (unionChildQuery) {
-          queryStr += `${fragIndent}... on ${valueTypeName} {\n${unionChildQuery}\n${fragIndent}}\n`;
+  /**
+   * Generate the query for the specified field
+   * @param curName name of the current field
+   * @param curParentType parent type of the current field
+   * @param curParentName parent name of the current field
+   * @param argumentsDict dictionary of arguments from all fields
+   * @param duplicateArgCounts map for deduping argument name collisions
+   * @param crossReferenceKeyList list of the cross reference
+   * @param curDepth current depth of field
+   * @param fromUnion adds additional depth for unions to avoid empty child
+   */
+  const generateQuery = (
+    curName,
+    curParentType,
+    curParentName,
+    argumentsDict = {},
+    duplicateArgCounts = {},
+    crossReferenceKeyList = [], // [`${curParentName}To${curName}Key`]
+    curDepth = 1,
+    fromUnion = false,
+  ) => {
+    const field = gqlSchema.getType(curParentType).getFields()[curName];
+    const curTypeName = field.type.toJSON().replace(/[[\]!]/g, '');
+    const curType = gqlSchema.getType(curTypeName);
+    let queryStr = '';
+    let childQuery = '';
+
+    if (curType.getFields) {
+      const crossReferenceKey = `${curParentName}To${curName}Key`;
+      if (
+        (!includeCrossReferences && crossReferenceKeyList.indexOf(crossReferenceKey) !== -1)
+        || (fromUnion ? curDepth - 2 : curDepth) > depthLimit
+      ) {
+        return '';
+      }
+      if (!fromUnion) {
+        crossReferenceKeyList.push(crossReferenceKey);
+      }
+      const childKeys = Object.keys(curType.getFields());
+      childQuery = childKeys
+        .filter((fieldName) => {
+          /* Exclude deprecated fields */
+          const fieldSchema = gqlSchema.getType(curType).getFields()[fieldName];
+          return includeDeprecatedFields || !fieldSchema.deprecationReason;
+        })
+        .map(cur => generateQuery(cur, curType, curName, argumentsDict, duplicateArgCounts,
+          crossReferenceKeyList, curDepth + 1, fromUnion).queryStr)
+        .filter(cur => Boolean(cur))
+        .join('\n');
+    }
+
+    if (!(curType.getFields && !childQuery)) {
+      queryStr = `${'    '.repeat(curDepth)}${field.name}`;
+      if (field.args.length > 0) {
+        const dict = getFieldArgsDict(field, duplicateArgCounts, argumentsDict);
+        Object.assign(argumentsDict, dict);
+        queryStr += `(${getArgsToVarsStr(dict)})`;
+      }
+      if (childQuery) {
+        queryStr += `{\n${childQuery}\n${'    '.repeat(curDepth)}}`;
+      }
+    }
+
+    /* Union types */
+    if (curType.astNode && curType.astNode.kind === 'UnionTypeDefinition') {
+      const types = curType.getTypes();
+      if (types && types.length) {
+        const indent = `${'    '.repeat(curDepth)}`;
+        const fragIndent = `${'    '.repeat(curDepth + 1)}`;
+        queryStr += '{\n';
+
+        for (let i = 0, len = types.length; i < len; i++) {
+          const valueTypeName = types[i];
+          const valueType = gqlSchema.getType(valueTypeName);
+          const unionChildQuery = Object.keys(valueType.getFields())
+            .map(cur => generateQuery(cur, valueType, curName, argumentsDict, duplicateArgCounts,
+              crossReferenceKeyList, curDepth + 2, true).queryStr)
+            .filter(cur => Boolean(cur))
+            .join('\n');
+
+          /* Exclude empty unions */
+          if (unionChildQuery) {
+            queryStr += `${fragIndent}... on ${valueTypeName} {\n${unionChildQuery}\n${fragIndent}}\n`;
+          }
         }
+        queryStr += `${indent}}`;
       }
-      queryStr += `${indent}}`;
     }
-  }
-  return { queryStr, argumentsDict };
-};
+    return { queryStr, argumentsDict };
+  };
 
-/**
- * Generate the query for the specified field
- * @param obj one of the root objects(Query, Mutation, Subscription)
- * @param description description of the current object
- */
-const generateFile = (obj, description) => {
-  let indexJs = 'const fs = require(\'fs\');\nconst path = require(\'path\');\n\n';
-  let outputFolderName;
-  switch (true) {
-    case /Mutation$/.test(description):
-      outputFolderName = 'mutations';
-      break;
-    case /Query$/.test(description):
-      outputFolderName = 'queries';
-      break;
-    case /Subscription$/.test(description):
-      outputFolderName = 'subscriptions';
-      break;
-    default:
-      console.log('[gqlg warning]:', 'description is required');
-  }
-  const writeFolder = path.join(destDirPath, `./${outputFolderName}`);
-  try {
-    fs.mkdirSync(writeFolder);
-  } catch (err) {
-    if (err.code !== 'EEXIST') throw err;
-  }
-  Object.keys(obj).forEach((type) => {
-    const field = gqlSchema.getType(description).getFields()[type];
-    /* Only process non-deprecated queries/mutations: */
-    if (includeDeprecatedFields || !field.deprecationReason) {
-      const queryResult = generateQuery(type, description);
-      const varsToTypesStr = getVarsToTypesStr(queryResult.argumentsDict);
-      let query = queryResult.queryStr;
-      let queryName;
-      switch (true) {
-        case /Mutation/.test(description):
-          queryName = 'mutation';
-          break;
-        case /Query/.test(description):
-          queryName = 'query';
-          break;
-        case /Subscription/.test(description):
-          queryName = 'subscription';
-          break;
-        default:
-          break;
+  /**
+   * Generate the query for the specified field
+   * @param obj one of the root objects(Query, Mutation, Subscription)
+   * @param description description of the current object
+   */
+  const generateFile = (obj, description) => {
+    let indexJs = 'const fs = require(\'fs\');\nconst path = require(\'path\');\n\n';
+    let outputFolderName;
+    switch (true) {
+      case /Mutation$/.test(description):
+        outputFolderName = 'mutations';
+        break;
+      case /Query$/.test(description):
+        outputFolderName = 'queries';
+        break;
+      case /Subscription$/.test(description):
+        outputFolderName = 'subscriptions';
+        break;
+      default:
+        console.log('[gqlg warning]:', 'description is required');
+    }
+    const writeFolder = path.join(destDirPath, `./${outputFolderName}`);
+    try {
+      fs.mkdirSync(writeFolder);
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+    }
+    Object.keys(obj).forEach((type) => {
+      const field = gqlSchema.getType(description).getFields()[type];
+      /* Only process non-deprecated queries/mutations: */
+      if (includeDeprecatedFields || !field.deprecationReason) {
+        const queryResult = generateQuery(type, description);
+        const varsToTypesStr = getVarsToTypesStr(queryResult.argumentsDict);
+        let query = queryResult.queryStr;
+        let queryName;
+        switch (true) {
+          case /Mutation/.test(description):
+            queryName = 'mutation';
+            break;
+          case /Query/.test(description):
+            queryName = 'query';
+            break;
+          case /Subscription/.test(description):
+            queryName = 'subscription';
+            break;
+          default:
+            break;
+        }
+        query = `${queryName || description.toLowerCase()} ${type}${varsToTypesStr ? `(${varsToTypesStr})` : ''}{\n${query}\n}`;
+        fs.writeFileSync(path.join(writeFolder, `./${type}.${fileExtension}`), query);
+        indexJs += `module.exports.${type} = fs.readFileSync(path.join(__dirname, '${type}.${fileExtension}'), 'utf8');\n`;
       }
-      query = `${queryName || description.toLowerCase()} ${type}${varsToTypesStr ? `(${varsToTypesStr})` : ''}{\n${query}\n}`;
-      fs.writeFileSync(path.join(writeFolder, `./${type}.${fileExtension}`), query);
-      indexJs += `module.exports.${type} = fs.readFileSync(path.join(__dirname, '${type}.${fileExtension}'), 'utf8');\n`;
-    }
-  });
-  fs.writeFileSync(path.join(writeFolder, 'index.js'), indexJs);
-  indexJsExportAll += `module.exports.${outputFolderName} = require('./${outputFolderName}');\n`;
-};
+    });
+    fs.writeFileSync(path.join(writeFolder, 'index.js'), indexJs);
+    indexJsExportAll += `module.exports.${outputFolderName} = require('./${outputFolderName}');\n`;
+  };
 
-if (gqlSchema.getMutationType()) {
-  generateFile(gqlSchema.getMutationType().getFields(), gqlSchema.getMutationType().name);
-} else {
-  console.log('[gqlg warning]:', 'No mutation type found in your schema');
+  if (gqlSchema.getMutationType()) {
+    generateFile(gqlSchema.getMutationType().getFields(), gqlSchema.getMutationType().name);
+  } else {
+    console.log('[gqlg warning]:', 'No mutation type found in your schema');
+  }
+
+  if (gqlSchema.getQueryType()) {
+    generateFile(gqlSchema.getQueryType().getFields(), gqlSchema.getQueryType().name);
+  } else {
+    console.log('[gqlg warning]:', 'No query type found in your schema');
+  }
+
+  if (gqlSchema.getSubscriptionType()) {
+    generateFile(gqlSchema.getSubscriptionType().getFields(), gqlSchema.getSubscriptionType().name);
+  } else {
+    console.log('[gqlg warning]:', 'No subscription type found in your schema');
+  }
+
+  fs.writeFileSync(path.join(destDirPath, 'index.js'), indexJsExportAll);
 }
 
-if (gqlSchema.getQueryType()) {
-  generateFile(gqlSchema.getQueryType().getFields(), gqlSchema.getQueryType().name);
-} else {
-  console.log('[gqlg warning]:', 'No query type found in your schema');
-}
+module.exports = main
 
-if (gqlSchema.getSubscriptionType()) {
-  generateFile(gqlSchema.getSubscriptionType().getFields(), gqlSchema.getSubscriptionType().name);
-} else {
-  console.log('[gqlg warning]:', 'No subscription type found in your schema');
-}
+if (require.main === module) {
+  program
+    .option('--schemaFilePath [value]', 'path of your graphql schema file')
+    .option('--destDirPath [value]', 'dir you want to store the generated queries')
+    .option('--depthLimit [value]', 'query depth you want to limit (The default is 100)')
+    .option('--assumeValid [value]', 'assume the SDL is valid (The default is false)')
+    .option('--ext [value]', 'extension file to use', 'gql')
+    .option('-C, --includeDeprecatedFields [value]', 'Flag to include deprecated fields (The default is to exclude)')
+    .option('-R, --includeCrossReferences', 'Flag to include fields that have been added to parent queries already (The default is to exclude)')
+    .parse(process.argv);
 
-fs.writeFileSync(path.join(destDirPath, 'index.js'), indexJsExportAll);
+  return main({...program, fileExtension: program.ext })
+}


### PR DESCRIPTION
Programmatic access makes it easier to control processes in other libraries, such as [here](https://github.com/zvictor/brainyduck/blob/0d42bc84ee6ef1d9daccfc27f944962e62897fa8/commands/build.js#L47-L51).

---

I don't know why github is showing such an aggressive diff for this PR. I just changed the indentation in most of the lines. I definitely didn't rewrite the whole thing 😅 

That's what I have actually done (partial):
![image](https://user-images.githubusercontent.com/181076/185072151-094543cc-6a63-4f75-94c2-2e3d4314b4df.png)
