### PR TITLE
Less restrictive Query/Mutation/Subscription regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,13 +173,13 @@ function main ({
     let indexJs = 'const fs = require(\'fs\');\nconst path = require(\'path\');\n\n';
     let outputFolderName;
     switch (true) {
-      case /Mutation$/.test(description):
+      case /Mutation.*$/.test(description):
         outputFolderName = 'mutations';
         break;
-      case /Query$/.test(description):
+      case /Query.*$/.test(description):
         outputFolderName = 'queries';
         break;
-      case /Subscription$/.test(description):
+      case /Subscription.*$/.test(description):
         outputFolderName = 'subscriptions';
         break;
       default:

--- a/index.js
+++ b/index.js
@@ -184,13 +184,13 @@ const generateFile = (obj, description) => {
   let indexJs = 'const fs = require(\'fs\');\nconst path = require(\'path\');\n\n';
   let outputFolderName;
   switch (true) {
-    case /Mutation$/.test(description):
+    case /Mutation.*$/.test(description):
       outputFolderName = 'mutations';
       break;
-    case /Query$/.test(description):
+    case /Query.*$/.test(description):
       outputFolderName = 'queries';
       break;
-    case /Subscription$/.test(description):
+    case /Subscription.*$/.test(description):
       outputFolderName = 'subscriptions';
       break;
     default:


### PR DESCRIPTION
Thanks so much for this library!!!👏 It's ace.

## Bug Fix
###  Schema
My server side schema plugin generates a schema as follows:
```
schema {
  query: RootQueryType
  mutation: RootMutationType
}
```

### Expected
```
yarn gqlg --schemaFilePath ./codegen/schema.graphql --destDirPath ./src/generated/schema --depthLimit 4
# produces
src/generated/schema/mutations
src/generated/schema/query
```

### Actual - fixed in this PR
```
yarn gqlg --schemaFilePath ./codegen/schema.graphql --destDirPath ./src/generated/schema --depthLimit 4
# produces
src/generated/schema/undefined
```

## General Info
I imagine the above problem is fairly common given that my schema above is auto-generated (Absinthe - Elixir)

Additionally the regex is parsing only what comes from this schema object i.e:

```
gqlSchema.getQueryType().name = RootQueryType
gqlSchema.getMutationType().name = RootMutationType
```

So it should be fairly stable.  **Unless** the below is common:

```
schema {
  query: RootQueryMutationType
  mutation: RootMutationQueryType
}
```

Though I hope not.  I can add a stricter Regex if required.  Or something not using a Regex if you like.